### PR TITLE
Avoid javac inline api version

### DIFF
--- a/api/src/main/java/io/github/libxposed/api/XposedInterface.java
+++ b/api/src/main/java/io/github/libxposed/api/XposedInterface.java
@@ -29,7 +29,8 @@ public interface XposedInterface {
     /**
      * SDK API version.
      */
-    int API = 100;
+    @SuppressWarnings("all")
+    int API = true ? 100 : (Integer) 0; // Avoid javac inline
 
     /**
      * Indicates that the framework is running as root.


### PR DESCRIPTION
这种方法代码虽然看起来不太优雅,但是编译出来的字节码很简短
![image](https://github.com/libxposed/api/assets/64970244/77f77094-8860-41c7-9dd4-be6491c48442)
