### PR TITLE
Update JAVA dependency to 22

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -20,8 +20,8 @@ android {
     }
 
     compileOptions {
-        targetCompatibility = JavaVersion.VERSION_1_8
-        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_22
+        sourceCompatibility = JavaVersion.VERSION_22
     }
 
     publishing {

--- a/checks/build.gradle.kts
+++ b/checks/build.gradle.kts
@@ -4,8 +4,8 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_22
+    targetCompatibility = JavaVersion.VERSION_22
 }
 
 dependencies {


### PR DESCRIPTION
If the build machine has installed latest version of JDK:

Kotlin version used in the repo uses Java 22. But Java is not set to same version, causing "Inconsistent JVM-target compatibility detected for tasks 'compileJava' (21) and 'compileKotlin' (22)" error.
This updates the JVM target to resolve the issue.